### PR TITLE
Allow manual deletion of the lines 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The project is based on Sherman's Circular Gallifreyan, for more information abo
 
 ####features:
 - doubled vowels/consonants
-- manual addition/deletion of lines
+- manual addition of lines
 - manually detach/reattach merged circles
 ...
 - support for punctuation, numbers?

--- a/gui.js
+++ b/gui.js
@@ -31,10 +31,11 @@ function Button(x, y, width, text, f) {
 function createGUI() {
     buttons.push(new Button(0, 0, 60, "save", function() { createFinalImage(); }));
     buttons.push(new Button(800 - 170, 0, 110, "line width", function() { }));
+    buttons.push(new Button(800 - 170, 30, 170, "delete line", function() { deleteLineMode = true; redraw(); }));
     buttons.push(new Button(800 - 60, 0, 30, "+",
         function() { lineWidth += 0.5; redraw(); }
     ));
-    buttons.push(new Button(800 - 30, 0, 30, "-",
+    buttons.push(new Button(800 - 30, 0, 30, "−",
         function() { lineWidth -= 0.5; if (lineWidth < 0.5) lineWidth = 0.5; redraw(); }
     ));
 }


### PR DESCRIPTION
Adds a button 'delete line', which, when clicked, emphasises all endpoints of the lines. When the user clicks at one of the lines' endpoints, the line is deleted. If the user clicks somewhere else, the translator returns to it's normal state.

Sorry, I closed the original pull request accidentaly.
