### PR TITLE
Make the words bigger in sentences with a lot of them

### DIFF
--- a/gallifreyan.js
+++ b/gallifreyan.js
@@ -399,7 +399,7 @@ function generateWords(words) {
 
     var delta = 2 * PI / words.length;
     var angle = PI / 2;
-    var r = words.length === 1 ? outerR * 0.8 : 1.7 * outerR / (words.length + 2);
+    var r = words.length === 1 ? outerR * 0.8 : 2.5 * outerR / (words.length + 4);
     var d = words.length === 1 ? 0 : outerR - r * 1.2;
 
     for (var i = 0; i < words.length; i++) {


### PR DESCRIPTION
When there are more words in a sentence than, let's say four/five, there is unnecessarily much white space between them. This commit makes the sentence look more compact, see the attached image. Top row = before, bottom row = after this commit.
![scale](https://cloud.githubusercontent.com/assets/4662123/18329197/95cfe938-7552-11e6-9e61-964c9c8cf116.png)
